### PR TITLE
feat(core): add store teardown and DestroyRef integration for memory …

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -258,6 +258,41 @@ export class FileUploaderComponent {
 
 ```
 
+Here is the updated `Axon` implementation updated with explicit memory management and automatic lifecycle hookup via Angular's `DestroyRef`.
+
+## Axon State Memory Management Best Practices
+
+Dynamic instantiation of micro-stores (e.g., individual store instances for table rows, tree nodes, or dynamic form fields) requires careful lifecycle handling to avoid memory leaks.
+
+### Automatic Teardown vs. Manual Teardown
+
+| Instantiation Context | Behavior | Cleanup Responsibility |
+| --- | --- | --- |
+| **Component Field / Constructor** | `inject(DestroyRef)` finds the component's injector. | **Automatic**: Automatically calls `destroy()` when the component unmounts. |
+| **Directive / Pipe** | Binds to the directive or pipe injection scope. | **Automatic**: Teardown happens automatically on directive destruction. |
+| **Root/Singleton Service** | Binds to the root injector. | **Manual**: `DestroyRef` won't trigger until the app shuts down. Call `axon.destroy()` when items are removed. |
+| **Array/Collection (Data Tables)** | Instantiated lazily inside arrays, maps, or methods. | **Manual**: Outside injection context. Call `.destroy()` when removing/replacing dynamic items. |
+
+### Best Practices for Row-Level State in Heavy Data Tables
+
+1. **Clear Collection References Explicitly:**
+When removing a row or resetting table data in a service, iterate over removed stores and invoke `.destroy()` before dropping references.
+```typescript
+removeRow(rowId: string) {
+  const store = this.rowStores.get(rowId);
+  if (store) {
+    store.destroy(); // Releases graph guards, history, and signal nodes
+    this.rowStores.delete(rowId);
+  }
+}
+
+```
+
+2. **Beware of Guard Closures:**
+Guards inside `AxonGraph` definitions often capture external variables or parent references. Calling `.destroy()` clears internal references to `this.graph`, severing retained object chains.
+3. **Avoid Unbound Reactive Effects Inside Dynamic Stores:**
+If extending `Axon` with custom `effect()` or RxJS `Observable` subscriptions, ensure they are registered to trigger `.destroy()` or managed within a `Subscription` bucket cleaned up in `destroy()`.
+
 ## Summary
 
 By leveraging `@ngx-axon/core`, you ensure your templates react purely to simple top-level constraints while keeping your internal transition paths clean, verifiable, and highly scalable. Try replacing your deeply conditional boolean flags with an axon pathway today!

--- a/projects/axon/src/lib/axon.spec.ts
+++ b/projects/axon/src/lib/axon.spec.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as angularCore from '@angular/core';
 import { Axon, AxonGraph } from './axon';
 
 enum State {
@@ -18,7 +19,7 @@ describe('Axon Library', () => {
   const graph: AxonGraph<State, Context> = {
     [State.Idle]: [State.Loading],
     [State.Loading]: [
-      State.Loading, // <--- ADDED: Self-loop to allow context updates in history
+      State.Loading, // Self-loop to allow context updates in history
       State.Error,
       State.Idle
     ],
@@ -158,7 +159,6 @@ describe('Axon Library', () => {
     expect(axon.canRedo()).toBe(true);
 
     // 3. Transition to a NEW state (Idle) instead of Redoing to Error
-    // This should trigger: currentIndex < this._history.length - 1
     axon.go(State.Idle);
 
     expect(axon.state()).toBe(State.Idle);
@@ -207,9 +207,133 @@ describe('Axon Library', () => {
     expect(incompleteAxon.state()).toBe(State.Error);
 
     // 3. Now we are in 'Error'. 
-    // Since 'Error' is not a key in incompleteGraph, 
-    // this.graph[status] will be undefined, triggering the ?? [] fallback.
     expect(incompleteAxon.can.Idle()).toBe(false);
     expect(incompleteAxon.go(State.Idle)).toBe(false);
+  });
+
+  // =========================================================================
+  // Memory Management & Teardown Lifecycle Tests
+  // =========================================================================
+
+  describe('Memory Management & Lifecycle (destroy)', () => {
+    it('should initialize with isDestroyed set to false', () => {
+      expect(axon.isDestroyed).toBe(false);
+    });
+
+    it('should set isDestroyed to true and clear history/references on destroy()', () => {
+      axon.go(State.Loading);
+      expect(axon.historySize).toBe(2);
+
+      axon.destroy();
+
+      expect(axon.isDestroyed).toBe(true);
+      expect(axon.historySize).toBe(0);
+    });
+
+    it('should be idempotent when destroy() is called multiple times', () => {
+      axon.destroy();
+      expect(axon.isDestroyed).toBe(true);
+
+      // Calling again should not throw or cause unexpected state
+      expect(() => axon.destroy()).not.toThrow();
+      expect(axon.isDestroyed).toBe(true);
+    });
+
+    it('should prevent state transitions (go) when destroyed', () => {
+      axon.destroy();
+
+      const result = axon.go(State.Loading);
+      expect(result).toBe(false);
+      expect(axon.state()).toBe(State.Idle); // Unchanged
+    });
+
+    it('should return false from canGo and can proxy when destroyed', () => {
+      // Get canGo signal before destruction
+      const canLoadingBefore = axon.can.Loading;
+      expect(canLoadingBefore()).toBe(true);
+
+      axon.destroy();
+
+      // Signals should evaluate to false after destroy
+      expect(axon.canGo(State.Loading)()).toBe(false);
+      expect(axon.can.Loading()).toBe(false);
+    });
+
+    it('should ignore undo and redo calls when destroyed', () => {
+      axon.go(State.Loading);
+      axon.destroy();
+
+      const stateBeforeUndo = axon.state();
+      axon.undo();
+      expect(axon.state()).toBe(stateBeforeUndo);
+
+      axon.redo();
+      expect(axon.state()).toBe(stateBeforeUndo);
+    });
+
+    it('should automatically register destroy callback when injected inside DestroyRef context', () => {
+      let registeredCleanupFn: (() => void) | undefined;
+
+      const destroyRefMock: Partial<angularCore.DestroyRef> = {
+        onDestroy: vi.fn((fn: () => void) => {
+          registeredCleanupFn = fn;
+          return () => { return; }; // Return a no-op cleanup function
+        })
+      };
+
+      const customInjector: Partial<angularCore.EnvironmentInjector> = {
+        get: (token: unknown) => {
+          if (token === angularCore.DestroyRef) {
+            return destroyRefMock;
+          }
+          return null;
+        }
+      };
+
+      let injectedAxon: Axon<State, Context> | undefined;
+
+      angularCore.runInInjectionContext(
+        customInjector as unknown as angularCore.EnvironmentInjector,
+        () => {
+          injectedAxon = Axon.create(State.Idle, { attempts: 0 }, graph);
+        }
+      );
+
+      expect(destroyRefMock.onDestroy).toHaveBeenCalledTimes(1);
+      expect(injectedAxon?.isDestroyed).toBe(false);
+
+      // Trigger the Angular DestroyRef lifecycle callback
+      registeredCleanupFn?.();
+
+      expect(injectedAxon?.isDestroyed).toBe(true);
+    });
+
+    it('should gracefully handle instantiation outside an Injection Context without error', () => {
+      let unhandledAxon: Axon<State, Context> | undefined;
+
+      expect(() => {
+        unhandledAxon = Axon.create(State.Idle, { attempts: 0 }, graph);
+      }).not.toThrow();
+
+      expect(unhandledAxon).toBeDefined();
+      expect(unhandledAxon?.isDestroyed).toBe(false);
+
+      // Manual teardown works as fallback
+      unhandledAxon?.destroy();
+      expect(unhandledAxon?.isDestroyed).toBe(true);
+    });
+
+it('should return false when evaluating a pre-existing canGo signal after destroy()', () => {
+  // 1. Store reference to the computed signal BEFORE destroy
+  const preCachedSignal = axon.canGo(State.Loading);
+  expect(preCachedSignal()).toBe(true);
+
+  // 2. Destroy the store (clears _canGoCache and sets _isDestroyed to true)
+  axon.destroy();
+
+  // 3. Evaluate the pre-existing signal reference directly
+  // This executes the computed closure body and hits line 90: if (this._isDestroyed) return false;
+  expect(preCachedSignal()).toBe(false);
+});
   });
 });

--- a/projects/axon/src/lib/axon.ts
+++ b/projects/axon/src/lib/axon.ts
@@ -1,4 +1,4 @@
-import { signal, computed, Signal, untracked, WritableSignal } from '@angular/core';
+import { signal, computed, Signal, untracked, WritableSignal, inject, DestroyRef } from '@angular/core';
 
 /**
  * Narrowed transition type to avoid 'any' in logic gates.
@@ -16,6 +16,7 @@ export class Axon<S extends string | number, T> {
   // History is kept as a Readonly array to enforce immutable updates
   private _history: readonly { readonly status: S; readonly context: T }[] = [];
   private readonly _historyIndex = signal(0);
+  private readonly _isDestroyed = signal(false);
 
   readonly state = computed(() => this._state().status);
   readonly context = computed(() => this._state().context);
@@ -33,12 +34,21 @@ export class Axon<S extends string | number, T> {
   constructor(
     private readonly initialState: S,
     private readonly initialContext: T,
-    private readonly graph: AxonGraph<S, T>,
+    private graph: AxonGraph<S, T>,
     private readonly historyLimit = 50
   ) {
     const initial = { status: this.initialState, context: this.initialContext };
     this._state = signal(initial);
     this._history = [initial];
+
+    // Automatically bind to Angular's DestroyRef if instantiated within an Injection Context
+    try {
+      const destroyRef = inject(DestroyRef, { optional: true });
+      destroyRef?.onDestroy(() => this.destroy());
+    } catch {
+      // Instantiated outside an Injection Context (e.g., dynamic factory outside component initialization, loops, or unit tests).
+      // Manual cleanup via axon.destroy() is required.
+    }
   }
 
   static create<S extends string | number, T>(
@@ -50,11 +60,34 @@ export class Axon<S extends string | number, T> {
     return new Axon<S, T>(initialState, context, graph, historyLimit);
   }
 
+  get isDestroyed(): boolean {
+    return this._isDestroyed();
+  }
+
+  public destroy(): void {
+    if (this._isDestroyed()) {
+      return;
+    }
+    this._isDestroyed.set(true);
+
+    // 1. Clear cached computed signals to allow GC of signal dependency nodes
+    this._canGoCache.clear();
+
+    // 2. Sever references to history and transition guard context closures
+    this._history = [];
+    this.graph = {} as AxonGraph<S, T>;
+  }
+
   canGo(nextState: S): Signal<boolean> {
+    if (this._isDestroyed()) {
+      return computed(() => false);
+    }
+
     let canGoSignal = this._canGoCache.get(nextState);
     
     if (!canGoSignal) {
       canGoSignal = computed(() => {
+        if (this._isDestroyed()) return false;
         const { status, context } = this._state();
         const allowed = this.graph[status] ?? [];
         
@@ -72,6 +105,10 @@ export class Axon<S extends string | number, T> {
   }
 
   go(nextState: S, updater?: (current: T) => T): boolean {
+    if (this._isDestroyed()) {
+      return false;
+    }
+
     return untracked(() => {
       if (this.canGo(nextState)()) {
         const current = this._state().context;
@@ -106,6 +143,7 @@ export class Axon<S extends string | number, T> {
   }
 
   undo(): void {
+    if (this._isDestroyed()) return;
     const currentIndex = this._historyIndex();
     if (currentIndex > 0) {
       const prevIndex = currentIndex - 1;
@@ -115,6 +153,7 @@ export class Axon<S extends string | number, T> {
   }
 
   redo(): void {
+    if (this._isDestroyed()) return;
     const currentIndex = this._historyIndex();
     if (currentIndex < this._history.length - 1) {
       const nextIndex = currentIndex + 1;


### PR DESCRIPTION
## 📝 Description
Introduce a public `destroy()` method and automatic lifecycle hooks to allow explicit cleanup of dynamically created store instances, preventing silent memory leaks in enterprise patterns like row-level state management.

## 🔗 Related Issue
Fixes # (issue number)
## 🛠 Type of Change
- [X] 🚀 Feature (new functionality)
- [ ] 🐞 Bug Fix (non-breaking change which fixes an issue)
- [ ] 🧹 Chore (refactoring, linting, maintenance)
- [X] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 💥 Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [X] My code follows the [Angular Style Guide](https://angular.dev/style-guide).
- [X] I have performed a self-review of my code.
- [X] I have run `ng lint axon` and fixed any warnings/errors.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with `ng test axon`.
- [X] I have updated the documentation (README/Docs) accordingly.
- [X] I have verified the changes in the `axon-demo` application.