### PR TITLE
feat(core): add transition logging and pathway tracing utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,83 @@ export class UploadComponent {
 > **How does `axon.can.Uploading()` work?**  
 > The `can` property provides a signal-based function for each possible state transition (e.g., `can.Uploading()`), returning `true` if the transition is currently allowed based on your FSM graph and any guards you define. This enables you to easily bind UI elements to the FSM's valid transitions.
 
+### Debugging & Pathway Tracing
+
+`ngx-axon` includes built-in, color-coded transition logging to help you visualize reactive data flow through your state pathways without cluttering your code with `console.log` statements.
+
+Loggers are automatically disabled in production builds via Angular's `ngDevMode` check, ensuring zero performance overhead or bundle bloat in production environments.
+
+#### Per-Instance Tracing
+
+Enable debugging on a specific store instance by passing an `AxonOptions` object to `Axon.create()` or `new Axon()`. You can also assign a custom `name` to identify specific micro-stores (e.g., individual table rows or dynamic form nodes).
+
+```typescript
+import { Axon } from 'ngx-axon/core';
+
+const rowStore = Axon.create(
+  OrderState.Idle,
+  { orderId: 'ORD-101', total: 49.99 },
+  orderGraph,
+  {
+    debug: true,          // Enables color-coded console logs for this instance
+    name: 'RowStore-101', // Custom tag prefix in console logs
+    historyLimit: 20      // Retains history limit configuration
+  }
+);
+
+// Trigger a transition
+rowStore.go(OrderState.Processing);
+
+```
+
+**Console Output:**
+
+```text
+[ngx-axon: RowStore-101] Idle ──> Processing | Context: { orderId: 'ORD-101', total: 49.99 }
+
+```
+
 ---
+
+#### Global Debug Configuration
+
+Enable tracing across all `Axon` instances in your application using `configureAxon()`. This is ideal during local development or when setting up environment-level toggles.
+
+```typescript
+import { configureAxon } from 'ngx-axon/core';
+import { environment } from '../environments/environment';
+
+// Enable debugging globally across all Axon stores
+if (!environment.production) {
+  configureAxon({ debug: true });
+}
+
+```
+
+> **Note:** Instance-level configuration takes precedence over global configuration. If global debugging is enabled, passing `{ debug: false }` to a specific store will silence that instance.
+
+---
+
+#### Configuration Options Reference
+
+The `AxonOptions` object replaces the optional `historyLimit` number parameter while remaining fully backward-compatible:
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `debug` | `boolean` | `false` | Enables console logging for state transitions on this instance. |
+| `name` | `string` | `undefined` | Optional identifier appended to log tags (e.g., `[ngx-axon: Name]`). |
+| `historyLimit` | `number` | `50` | Maximum number of undo/redo history entries retained. |
+
+To reset global settings (useful in test teardowns), use `resetAxonGlobalConfig()`:
+
+```typescript
+import { resetAxonGlobalConfig } from 'ngx-axon/core';
+
+afterEach(() => {
+  resetAxonGlobalConfig();
+});
+
+```
 
 ### Advanced: Logic Guards
 

--- a/projects/axon-demo/src/app/app.ts
+++ b/projects/axon-demo/src/app/app.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Axon, AxonGraph } from '@ngx-axon/core'; // Adjusted path to your library file
+import { Axon, AxonGraph, configureAxon } from '@ngx-axon/core'; // Adjusted path to your library file
 
 enum OrderStatus {
   Draft = 'Draft',
@@ -44,6 +44,10 @@ export class App {
     this.orderGraph,
     10 // History Limit
   );
+
+  constructor() {
+    configureAxon({debug: true});
+  }
 
   // 3. Simple Action wrappers
   submit(): void { this.order.go(OrderStatus.Pending); }

--- a/projects/axon/src/lib/axon.spec.ts
+++ b/projects/axon/src/lib/axon.spec.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as angularCore from '@angular/core';
-import { Axon, AxonGraph } from './axon';
+import {
+  Axon,
+  AxonGraph,
+  configureAxon,
+  resetAxonGlobalConfig
+} from './axon';
 
 enum State {
   Idle = 'Idle',
@@ -27,13 +32,20 @@ describe('Axon Library', () => {
   };
 
   beforeEach(() => {
+    resetAxonGlobalConfig();
     // Limit of 3: [State1, State2, State3]
     axon = Axon.create(State.Idle, { attempts: 0 }, graph, 3);
+  });
+
+  afterEach(() => {
+    resetAxonGlobalConfig();
+    vi.restoreAllMocks();
   });
 
   it('should restore context exactly as it was during undo', () => {
     // 1. Idle {0} -> Loading {1} (Valid)
     axon.go(State.Loading, (ctx) => ({ ...ctx, attempts: 1 }));
+
     // 2. Loading {1} -> Loading {2} (Valid now because of self-loop)
     axon.go(State.Loading, (ctx) => ({ ...ctx, attempts: 2 }));
 
@@ -248,15 +260,19 @@ describe('Axon Library', () => {
     });
 
     it('should return false from canGo and can proxy when destroyed', () => {
-      // Get canGo signal before destruction
-      const canLoadingBefore = axon.can.Loading;
-      expect(canLoadingBefore()).toBe(true);
+      axon.destroy();
+
+      expect(axon.canGo(State.Loading)()).toBe(false);
+      expect(axon.can.Loading()).toBe(false);
+    });
+
+    it('should return false when evaluating a pre-existing canGo signal after destroy()', () => {
+      const preCachedSignal = axon.canGo(State.Loading);
+      expect(preCachedSignal()).toBe(true);
 
       axon.destroy();
 
-      // Signals should evaluate to false after destroy
-      expect(axon.canGo(State.Loading)()).toBe(false);
-      expect(axon.can.Loading()).toBe(false);
+      expect(preCachedSignal()).toBe(false);
     });
 
     it('should ignore undo and redo calls when destroyed', () => {
@@ -323,17 +339,132 @@ describe('Axon Library', () => {
       expect(unhandledAxon?.isDestroyed).toBe(true);
     });
 
-it('should return false when evaluating a pre-existing canGo signal after destroy()', () => {
-  // 1. Store reference to the computed signal BEFORE destroy
-  const preCachedSignal = axon.canGo(State.Loading);
-  expect(preCachedSignal()).toBe(true);
+    it('should return false when evaluating a pre-existing canGo signal after destroy()', () => {
+      // 1. Store reference to the computed signal BEFORE destroy
+      const preCachedSignal = axon.canGo(State.Loading);
+      expect(preCachedSignal()).toBe(true);
 
-  // 2. Destroy the store (clears _canGoCache and sets _isDestroyed to true)
-  axon.destroy();
+      // 2. Destroy the store (clears _canGoCache and sets _isDestroyed to true)
+      axon.destroy();
 
-  // 3. Evaluate the pre-existing signal reference directly
-  // This executes the computed closure body and hits line 90: if (this._isDestroyed) return false;
-  expect(preCachedSignal()).toBe(false);
-});
+      // 3. Evaluate the pre-existing signal reference directly
+      // This executes the computed closure body and hits line 90: if (this._isDestroyed) return false;
+      expect(preCachedSignal()).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // Developer Experience & Debug Logging Tests
+  // =========================================================================
+
+  describe('Developer Experience & Debug Logging', () => {
+    it('should not log transitions by default when debug is unconfigured', () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => { return; });
+
+      axon.go(State.Loading);
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+
+    it('should log transitions when debug: true is passed in instance options', () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => { return; });
+
+      const debugAxon = Axon.create(State.Idle, { attempts: 0 }, graph, {
+        debug: true,
+        historyLimit: 10
+      });
+
+      debugAxon.go(State.Loading);
+
+      expect(consoleSpy).toHaveBeenCalledTimes(1);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '%c[ngx-axon]%c Idle ──> Loading %c| Context:',
+        'color: #8b5cf6; font-weight: bold;',
+        'color: inherit; font-weight: bold;',
+        'color: #6b7280;',
+        { attempts: 0 }
+      );
+    });
+
+    it('should include store name in tag when name option is provided', () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => { return; });
+
+      const namedAxon = Axon.create(State.Idle, { attempts: 0 }, graph, {
+        debug: true,
+        name: 'RowStore'
+      });
+
+      namedAxon.go(State.Loading);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '%c[ngx-axon: RowStore]%c Idle ──> Loading %c| Context:',
+        'color: #8b5cf6; font-weight: bold;',
+        'color: inherit; font-weight: bold;',
+        'color: #6b7280;',
+        { attempts: 0 }
+      );
+    });
+
+    it('should log transitions globally when configureAxon({ debug: true }) is called', () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => { return; });
+
+      configureAxon({ debug: true });
+
+      const defaultAxon = Axon.create(State.Idle, { attempts: 0 }, graph);
+      defaultAxon.go(State.Loading);
+
+      expect(consoleSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should allow instance debug: false to override global debug: true', () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => { return; });
+
+      configureAxon({ debug: true });
+
+      const mutedAxon = Axon.create(State.Idle, { attempts: 0 }, graph, {
+        debug: false
+      });
+
+      mutedAxon.go(State.Loading);
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+
+    it('should respect custom history limit when passed inside AxonOptions object', () => {
+      const limitedAxon = Axon.create(State.Idle, { attempts: 0 }, graph, {
+        historyLimit: 2
+      });
+
+      limitedAxon.go(State.Loading);
+      limitedAxon.go(State.Error);
+      limitedAxon.go(State.Idle);
+
+      expect(limitedAxon.historySize).toBe(2);
+    });
+
+    it('should suppress log output when ngDevMode is explicitly false (production mode)', () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => { return; });
+
+      // 1. Safely mock Angular production mode without 'any'
+      const globalRef = globalThis as unknown as { ngDevMode?: boolean };
+      const previousNgDevMode = globalRef.ngDevMode;
+      globalRef.ngDevMode = false;
+
+      try {
+        // 2. Create store with debug explicitly enabled
+        const debugAxon = Axon.create(State.Idle, { attempts: 0 }, graph, {
+          debug: true
+        });
+
+        // 3. Trigger transition
+        debugAxon.go(State.Loading);
+
+        // 4. Assert that ngDevMode = false suppressed the log output
+        expect(consoleSpy).not.toHaveBeenCalled();
+      } finally {
+        // 5. Restore original ngDevMode state
+        globalRef.ngDevMode = previousNgDevMode;
+      }
+    });
   });
 });

--- a/projects/axon/src/lib/axon.ts
+++ b/projects/axon/src/lib/axon.ts
@@ -1,5 +1,7 @@
 import { signal, computed, Signal, untracked, WritableSignal, inject, DestroyRef } from '@angular/core';
 
+declare const ngDevMode: boolean | undefined;
+
 /**
  * Narrowed transition type to avoid 'any' in logic gates.
  */
@@ -9,6 +11,28 @@ export type AxonTransition<S extends string | number, T> =
 
 export type AxonGraph<S extends string | number, T> = Readonly<Partial<Record<S, readonly AxonTransition<S, T>[]>>>;
 
+export interface AxonOptions {
+  readonly debug?: boolean;
+  readonly historyLimit?: number;
+  readonly name?: string;
+}
+
+export interface AxonGlobalConfig {
+  debug?: boolean;
+}
+
+let globalConfig: AxonGlobalConfig = {
+  debug: false
+};
+
+export function configureAxon(config: AxonGlobalConfig): void {
+  globalConfig = { ...globalConfig, ...config };
+}
+
+export function resetAxonGlobalConfig(): void {
+  globalConfig = { debug: false };
+}
+
 export class Axon<S extends string | number, T> {
   private readonly _state: WritableSignal<{ readonly status: S; readonly context: T }>;
   private readonly _canGoCache = new Map<S, Signal<boolean>>();
@@ -17,6 +41,10 @@ export class Axon<S extends string | number, T> {
   private _history: readonly { readonly status: S; readonly context: T }[] = [];
   private readonly _historyIndex = signal(0);
   private readonly _isDestroyed = signal(false);
+
+  private readonly _debug?: boolean;
+  private readonly _name?: string;
+  private readonly historyLimit: number;
 
   readonly state = computed(() => this._state().status);
   readonly context = computed(() => this._state().context);
@@ -35,8 +63,16 @@ export class Axon<S extends string | number, T> {
     private readonly initialState: S,
     private readonly initialContext: T,
     private graph: AxonGraph<S, T>,
-    private readonly historyLimit = 50
+    options?: number | AxonOptions
   ) {
+    if (typeof options === 'number') {
+      this.historyLimit = options;
+    } else {
+      this.historyLimit = options?.historyLimit ?? 50;
+      this._debug = options?.debug;
+      this._name = options?.name;
+    }
+
     const initial = { status: this.initialState, context: this.initialContext };
     this._state = signal(initial);
     this._history = [initial];
@@ -55,9 +91,9 @@ export class Axon<S extends string | number, T> {
     initialState: S,
     context: T,
     graph: AxonGraph<S, T>,
-    historyLimit = 50
+    options?: number | AxonOptions
   ): Axon<S, T> {
-    return new Axon<S, T>(initialState, context, graph, historyLimit);
+    return new Axon<S, T>(initialState, context, graph, options);
   }
 
   get isDestroyed(): boolean {
@@ -111,6 +147,7 @@ export class Axon<S extends string | number, T> {
 
     return untracked(() => {
       if (this.canGo(nextState)()) {
+        const fromStatus = this._state().status;
         const current = this._state().context;
         const newState = { 
           status: nextState, 
@@ -133,7 +170,7 @@ export class Axon<S extends string | number, T> {
         }
 
         this._history = nextHistory;
-        console.log('Transitioned with history: ', this._history);
+        this._logTransition(fromStatus, nextState, newState.context);
         this._historyIndex.set(this._history.length - 1);
         this._state.set(newState);
         return true;
@@ -168,5 +205,25 @@ export class Axon<S extends string | number, T> {
 
   is(status: S): boolean {
     return this._state().status === status;
+  }
+
+  private _logTransition(fromState: S, toState: S, context: T): void {
+    if (typeof ngDevMode !== 'undefined' && !ngDevMode) {
+      return;
+    }
+
+    const isDebug = this._debug ?? globalConfig.debug ?? false;
+    if (!isDebug) {
+      return;
+    }
+
+    const tag = this._name ? `[ngx-axon: ${this._name}]` : '[ngx-axon]';
+    console.log(
+      `%c${tag}%c ${fromState} ──> ${toState} %c| Context:`,
+      'color: #8b5cf6; font-weight: bold;',
+      'color: inherit; font-weight: bold;',
+      'color: #6b7280;',
+      context
+    );
   }
 }


### PR DESCRIPTION
## 📝 Description
Introduce built-in, color-coded state transition logging to trace reactive signal flow across axon pathways, supporting per-instance overrides, global configuration, and production tree-shaking.

Key changes:
- Support `AxonOptions` object (`debug`, `name`, `historyLimit`) in `Axon.create()` / constructor while preserving backward compatibility with numeric `historyLimit` args.
- Add `configureAxon()` and `resetAxonGlobalConfig()` functions to configure debugging globally across all store instances.
- Print formatted, color-coded directional logs (`[ngx-axon: Name] FromState ──> ToState | Context: ...`) on successful transitions.
- Guard log execution with `ngDevMode` checks (`typeof ngDevMode !== 'undefined' && !ngDevMode`) to eliminate performance overhead in production builds.
- Add Vitest test cases covering logging formatting, name tags, global overrides, and `ngDevMode` suppression.
- Document tracing features and configuration options in the README.

## 🔗 Related Issue
Fixes #37

## 🛠 Type of Change
- [X] 🚀 Feature (new functionality)
- [ ] 🐞 Bug Fix (non-breaking change which fixes an issue)
- [ ] 🧹 Chore (refactoring, linting, maintenance)
- [X] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 💥 Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [X] My code follows the [Angular Style Guide](https://angular.dev/style-guide).
- [X] I have performed a self-review of my code.
- [X] I have run `ng lint axon` and fixed any warnings/errors.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with `ng test axon`.
- [X] I have updated the documentation (README/Docs) accordingly.
- [X] I have verified the changes in the `axon-demo` application.