### PR TITLE
docs(core): add architectural recipes for HTTP, entity, and form patt…

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,279 @@ const graph: AxonGraph<State, Context> = {
 };
 ```
 
+## Architectural Recipes
+
+### 1. HTTP Requests & Async Lifecycles
+
+Managing async operations with raw booleans like `isLoading` or `isError` often leads to impossible UI states (e.g., displaying a loading spinner and an error banner simultaneously). `Axon` eliminates invalid states by modeling the API lifecycle as an explicit state machine graph.
+
+```typescript
+import { Component, inject, signal } from '@angular/core';
+import { Axon, AxonGraph } from 'ngx-axon/core';
+
+export type ApiState = 'Idle' | 'Loading' | 'Success' | 'Error';
+
+export interface User {
+  readonly id: string;
+  readonly name: string;
+  readonly email: string;
+}
+
+export interface FetchContext<T> {
+  readonly data: T | null;
+  readonly error: string | null;
+  readonly attempts: number;
+}
+
+const apiGraph: AxonGraph<ApiState, FetchContext<User>> = {
+  Idle: ['Loading'],
+  Loading: ['Success', 'Error'],
+  Error: ['Loading', 'Idle'], // Retry or Reset
+  Success: ['Loading', 'Idle'] // Refresh or Reset
+};
+
+@Component({
+  selector: 'app-user-profile',
+  standalone: true,
+  template: `
+    @if (axon.is('Loading')) {
+      <p>Loading user profile (Attempt {{ axon.context().attempts }})...</p>
+    }
+
+    @if (axon.is('Success')) {
+      <p>Welcome, {{ axon.context().data?.name }}!</p>
+      <button (click)="fetchUser('123')">Refresh</button>
+    }
+
+    @if (axon.is('Error')) {
+      <p class="error">{{ axon.context().error }}</p>
+      <button (click)="fetchUser('123')">Retry</button>
+    }
+  `
+})
+export class UserProfileComponent {
+  readonly axon = Axon.create<ApiState, FetchContext<User>>(
+    'Idle',
+    { data: null, error: null, attempts: 0 },
+    apiGraph,
+    { name: 'UserProfileStore' }
+  );
+
+  async fetchUser(userId: string): Promise<void> {
+    // 1. Guard against duplicate or invalid concurrent requests
+    const transitioned = this.axon.go('Loading', (ctx) => ({
+      ...ctx,
+      attempts: ctx.attempts + 1,
+      error: null
+    }));
+
+    if (!transitioned) {
+      return; // Request already in progress or transition guarded
+    }
+
+    try {
+      const user = await this.mockApiCall(userId);
+      this.axon.go('Success', (ctx) => ({ ...ctx, data: user }));
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to fetch user';
+      this.axon.go('Error', (ctx) => ({ ...ctx, error: errorMessage }));
+    }
+  }
+
+  private mockApiCall(id: string): Promise<User> {
+    return new Promise((resolve) =>
+      setTimeout(() => resolve({ id, name: 'Alex Developer', email: 'alex@example.com' }), 1000)
+    );
+  }
+}
+
+```
+
+**Why Axon Handles This Elegantly:**
+
+* **Impossible State Elimination:** Your template cannot accidentally render both `Success` data and an `Error` message.
+* **Concurrent Request Prevention:** Calling `fetchUser()` while state is already `'Loading'` automatically evaluates `axon.go('Loading')` to `false` based on the graph definition, preventing duplicate network calls.
+
 ---
+
+### 2. Entity & Collection Management (Row-Level Micro-Stores)
+
+When managing complex collections (like heavy data tables, Kanban boards, or order items), binding global store state to individual items forces unnecessary re-renders. `Axon` allows you to instantiate independent, micro-store instances per row with automated lifecycle teardown.
+
+```typescript
+import { Injectable } from '@angular/core';
+import { Axon, AxonGraph } from 'ngx-axon/core';
+
+export type RowState = 'Read' | 'Editing' | 'Saving' | 'Error';
+
+export interface OrderRowContext {
+  readonly id: string;
+  readonly quantity: number;
+  readonly price: number;
+  readonly errorMessage?: string;
+}
+
+const rowGraph: AxonGraph<RowState, OrderRowContext> = {
+  Read: ['Editing'],
+  Editing: [
+    'Read', // Cancel
+    {
+      to: 'Saving',
+      guard: (ctx) => ctx.quantity > 0 && ctx.price >= 0 // Business Guard
+    }
+  ],
+  Saving: ['Read', 'Error'],
+  Error: ['Editing', 'Read']
+};
+
+export type RowAxon = Axon<RowState, OrderRowContext>;
+
+@Injectable({ providedIn: 'root' })
+export class OrderTableService {
+  private readonly rows = new Map<string, RowAxon>();
+
+  createRowStore(initial: OrderRowContext): RowAxon {
+    const store = Axon.create<RowState, OrderRowContext>('Read', initial, rowGraph, {
+      name: `OrderRow-${initial.id}`
+    });
+    this.rows.set(initial.id, store);
+    return store;
+  }
+
+  getRowStore(id: string): RowAxon | undefined {
+    return this.rows.get(id);
+  }
+
+  removeRow(id: string): void {
+    const store = this.rows.get(id);
+    if (store) {
+      // Safely disconnect signal dependency nodes and sever graph references
+      store.destroy();
+      this.rows.delete(id);
+    }
+  }
+
+  clearAll(): void {
+    for (const store of this.rows.values()) {
+      store.destroy();
+    }
+    this.rows.clear();
+  }
+}
+
+```
+
+**Why Axon Handles This Elegantly:**
+
+* **Targeted Isolation:** Re-renders and reactive computation remain strictly scoped to the modified row.
+* **Guaranteed Memory Safety:** Invoking `.destroy()` during row deletion breaks guard closures, clears cached signals, and ensures the Garbage Collector reclaims memory instantly.
+
+---
+
+### 3. Form State Integration & Guarded Submissions
+
+Connecting Angular Reactive Forms or Signal Forms to an `Axon` pathway decouples business transition rules from form templates. Machine guards prevent invalid submissions at the state layer.
+
+```typescript
+import { Component } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Axon, AxonGraph } from 'ngx-axon/core';
+
+export type FormState = 'Pristine' | 'Editing' | 'Submitting' | 'Submitted' | 'Error';
+
+export interface CheckoutFormContext {
+  readonly email: string;
+  readonly agreeToTerms: boolean;
+  readonly serverError: string | null;
+}
+
+const checkoutGraph: AxonGraph<FormState, CheckoutFormContext> = {
+  Pristine: ['Editing'],
+  Editing: [
+    'Editing', // Field updates
+    {
+      to: 'Submitting',
+      // Machine-level Guard: Guarantees submission state cannot be reached without terms agreement
+      guard: (ctx) => ctx.agreeToTerms && ctx.email.includes('@')
+    }
+  ],
+  Submitting: ['Submitted', 'Error'],
+  Error: ['Editing'],
+  Submitted: ['Pristine']
+};
+
+@Component({
+  selector: 'app-checkout-form',
+  standalone: true,
+  imports: [ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form" (ngSubmit)="submitCheckout()">
+      <input type="email" formControlName="email" (input)="onFieldChange()" placeholder="Email" />
+      
+      <label>
+        <input type="checkbox" formControlName="agreeToTerms" (change)="onFieldChange()" />
+        I agree to terms
+      </label>
+
+      <!-- The 'can' proxy reactively checks machine guards -->
+      <button type="submit" [disabled]="!axon.can.Submitting()">
+        @if (axon.is('Submitting')) {
+          Processing...
+        } @else {
+          Complete Checkout
+        }
+      </button>
+    </form>
+  `
+})
+export class CheckoutFormComponent {
+  readonly form = new FormGroup({
+    email: new FormControl('', { nonNullable: true, validators: [Validators.required, Validators.email] }),
+    agreeToTerms: new FormControl(false, { nonNullable: true, validators: [Validators.requiredTrue] })
+  });
+
+  readonly axon = Axon.create<FormState, CheckoutFormContext>(
+    'Pristine',
+    { email: '', agreeToTerms: false, serverError: null },
+    checkoutGraph,
+    { name: 'CheckoutForm' }
+  );
+
+  onFieldChange(): void {
+    const rawValues = this.form.getRawValue();
+    
+    this.axon.go('Editing', (ctx) => ({
+      ...ctx,
+      email: rawValues.email,
+      agreeToTerms: rawValues.agreeToTerms
+    }));
+  }
+
+  async submitCheckout(): Promise<void> {
+    const isAllowed = this.axon.go('Submitting');
+    if (!isAllowed) {
+      return; // Guard rejected transition (e.g. invalid form state)
+    }
+
+    try {
+      await this.fakeSubmitApi(this.axon.context());
+      this.axon.go('Submitted');
+    } catch {
+      this.axon.go('Error', (ctx) => ({ ...ctx, serverError: 'Payment failed' }));
+    }
+  }
+
+  private fakeSubmitApi(_payload: CheckoutFormContext): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 1500));
+  }
+}
+
+```
+
+**Why Axon Handles This Elegantly:**
+
+* **Reactive Button Disabling:** `axon.can.Submitting()` is a memoized Angular Signal that automatically reflects both Angular form state and custom machine guards without template boilerplate.
+* **Double-Submit Proof:** While in `'Submitting'`, transition to `'Submitting'` is disallowed by the graph definition, preventing repeated button clicks from firing multiple HTTP calls.
 
 ### License
 


### PR DESCRIPTION
## 📝 Description
Add a dedicated "Architectural Recipes" section to the documentation featuring fully-typed, copy-pasteable implementation patterns to lower the library's learning curve.

Key additions:
- HTTP Requests & Async Lifecycles: Demonstrates modeling API states (Idle, Loading, Success, Error) to eliminate impossible UI states and prevent duplicate concurrent requests.
- Entity & Collection Management: Details best practices for creating row-level micro-stores in data tables with explicit lifecycle cleanup via `.destroy()`.
- Form State Integration: Shows how to bind Angular Reactive Forms to Axon state graphs, leveraging reactive transition guards (`axon.can.Submitting()`) and double-submit prevention.
- Highlight architectural benefits of Axon's state-machine model over traditional state management stores for each use case.

## 🔗 Related Issue
Fixes #38

## 🛠 Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐞 Bug Fix (non-breaking change which fixes an issue)
- [ ] 🧹 Chore (refactoring, linting, maintenance)
- [X] 📝 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 💥 Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [X] My code follows the [Angular Style Guide](https://angular.dev/style-guide).
- [X] I have performed a self-review of my code.
- [X] I have run `ng lint axon` and fixed any warnings/errors.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with `ng test axon`.
- [X] I have updated the documentation (README/Docs) accordingly.
- [X] I have verified the changes in the `axon-demo` application.